### PR TITLE
Correct how we reference PAT_USER

### DIFF
--- a/.github/workflows/update-theme-history.yml
+++ b/.github/workflows/update-theme-history.yml
@@ -83,6 +83,6 @@ jobs:
           bin/pulltheme.sh
           bin/pushtheme.sh $LATEST_RELEASED_VERSION
           cd fusionauth-theme-history
-          git push --tags https://$PAT_USER:${{ secrets.PAT_FOR_COMMITS }}@github.com/FusionAuth/fusionauth-theme-history main 
+          git push --tags https://${{ secrets.PAT_USER }}:${{ secrets.PAT_FOR_COMMITS }}@github.com/FusionAuth/fusionauth-theme-history main 
         shell: bash
 


### PR DESCRIPTION
This [run](https://github.com/FusionAuth/fusionauth-theme-history-updater/actions/runs/10743578434) failed because I was referencing PAT_USER, which is a secret, as a env var, not a secret. 

Since this is the first release the updater was running for, that is the first time it failed.